### PR TITLE
feat: add add-cluster.sh script

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,29 @@
+= CodeReady Toolchain
+
+This repo is for controllers, libs, scripts, make files, etc to be shared between host and member operators.
+
+
+== Scripts
+
+=== add-cluster.sh
+
+The CodeReady Toolchain architecture contains two types of clusters `host` and `member`.
+To connect these two clusters together it is necessary to run a script link:scripts/add-cluster.sh[] that takes two arguments:
+
+1. type of the cluster to be added
+2. name of the cluster to be added
+
+The script is working with Minishift profiles and expects that there are two clusters (profiles) called `host` and `member`.
+To be able to run the script, you need to have both clusters prepared, which means:
+
+- created CRDs
+- created ServiceAccount with ClusterRole/ClusterRoleBinding
+
+When the script is executed with parameters `add-cluster.sh member member-cluster` then it does these steps:
+
+1. goes to the `member` profile
+2. takes a secret of the SA (from the `member`)
+3. takes API endpoint of the `member` cluster from Kube config
+4. goes to `host` profile
+5. creates a secret with the SA token taken from the `member`
+6. creates `KubeFedCluster` CR representing the added `member`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,0 @@
-# toolchain
-CodeReady Toolchain
-
-This repo is for controllers, libs, scripts, make files, etc to be shared between host and member operators.

--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+
+JOINING_CLUSTER_TYPE=$1
+JOINING_CLUSTER_NAME=$2
+OPERATOR_NS=${OPERATOR_NAMESPACE:toolchain-member-operator}
+SA_NAME=${JOINING_CLUSTER_TYPE}"-operator"
+
+CLUSTER_JOIN_TO="host"
+if [[ ${JOINING_CLUSTER_TYPE} == "host" ]]; then
+  CLUSTER_JOIN_TO="member"
+fi
+
+echo "Switching to profile ${JOINING_CLUSTER_TYPE}"
+minishift profile set ${JOINING_CLUSTER_TYPE}
+oc login -u=system:admin
+oc project "toolchain-${JOINING_CLUSTER_TYPE}-operator"
+
+echo "Getting ${JOINING_CLUSTER_TYPE} SA token"
+SA_SECRET=`oc get sa ${SA_NAME} -o json | jq -r .secrets[].name | grep token`
+SA_TOKEN=`oc get secret ${SA_SECRET} -o json | jq -r '.data["token"]' | base64 -d`
+SA_CA_CRT=`oc get secret ${SA_SECRET} -o json | jq -r '.data["ca.crt"]'`
+
+API_ENDPOINT=`oc config view --raw --minify -o json | jq -r '.clusters[0].cluster["server"]'`
+
+echo "Switching to profile ${CLUSTER_JOIN_TO}"
+minishift profile set ${CLUSTER_JOIN_TO}
+oc login -u=system:admin
+oc project "toolchain-${CLUSTER_JOIN_TO}-operator"
+
+oc create secret generic ${SA_NAME}-${JOINING_CLUSTER_NAME} --from-literal=token="${SA_TOKEN}" --from-literal=ca.crt="${SA_CA_CRT}"
+
+KUBEFEDCLUSTER_CRD="apiVersion: core.kubefed.k8s.io/v1beta1
+kind: KubeFedCluster
+metadata:
+  name: ${JOINING_CLUSTER_NAME}
+  namespace: ${OPERATOR_NS}
+  labels:
+    type: ${JOINING_CLUSTER_TYPE}
+spec:
+  apiEndpoint: ${API_ENDPOINT}
+  caBundle: ${SA_CA_CRT}
+  secretRef:
+    name: ${SA_NAME}-${JOINING_CLUSTER_NAME}
+"
+
+echo "Creating KubeFedCluster representation of ${JOINING_CLUSTER_TYPE} in ${CLUSTER_JOIN_TO}:"
+echo ${KUBEFEDCLUSTER_CRD}
+
+cat <<EOF | oc apply -f -
+${KUBEFEDCLUSTER_CRD}
+EOF


### PR DESCRIPTION
add script `add-cluster.sh` that takes two arguments:
  1. type of the cluster to be added
  2. name of the cluster to be added
  - The script is working with minishift profiles and expects that there are only two clusters (profiles) called `host` and `member`
  - to be able to run the script, you need to have both clusters prepared, which means:
    - created CRDs
    - created SA with cluster role binding 
  - what does the script do? When you want to add a Member cluster to the system, then you run `add-cluster.sh member member-cluster` and the script:
    1. goes to the member profile
    2. takes a secret of the SA (from the member)
    3. takes API endpoint of the member cluster from Kube config
    4. goes to host cluster
    5. creates a secret with the SA token taken from the member
    6. creates KubeFedCluster representing the member